### PR TITLE
Add card delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ trello login [--api-key <KEY>] [--api-token <TOKEN>]
 trello card create <LIST> <NAME> [-d <DESC>] [-p <POSITION>] [-b <BOARD>]
 trello card update <CARD_ID> [-d <DESC>] [-l <LABEL>]... [--clear-label <LABEL>]... [-c <TEXT>] [-a] [-r]
 trello card move <CARD_ID> <POSITION>
+trello card delete <CARD_ID>
 trello card find <PATTERN> [-b <BOARD>] [-l <LIST>] [--json]
 trello card show <CARD_ID> [--json] [--comments]
 trello list move <LIST_ID> <POSITION>

--- a/src/client.rs
+++ b/src/client.rs
@@ -169,6 +169,11 @@ impl TrelloClient {
         self.get(&path)
     }
 
+    pub fn delete_card(&self, card_id: &str) -> Result<()> {
+        let path = format!("/cards/{}", card_id);
+        self.delete(&path)
+    }
+
     pub fn get_board_labels(&self, board_id: &str) -> Result<Vec<Label>> {
         let path = format!("/boards/{}/labels", board_id);
         self.get(&path)


### PR DESCRIPTION
Summary
- Add trello card delete <CARD_ID> CLI subcommand
- Add TrelloClient::delete_card and Wire deletion handling in the command runner
- Add CLI parser coverage for card delete
- Document the command in README